### PR TITLE
Fix conversion between Euler angles to quaternions

### DIFF
--- a/kfusion/src/utils/dual_quaternion.hpp
+++ b/kfusion/src/utils/dual_quaternion.hpp
@@ -44,7 +44,7 @@ namespace kfusion {
                 rotation_.y_ = cos(roll / 2) * sin(pitch / 2) * cos(yaw / 2) +
                                sin(roll / 2) * cos(pitch / 2) * sin(yaw / 2);
                 rotation_.z_ = cos(roll / 2) * cos(pitch / 2) * sin(yaw / 2) -
-                               sin(roll / 2) * cos(pitch / 2) * cos(yaw / 2);
+                               sin(roll / 2) * sin(pitch / 2) * cos(yaw / 2);
 
                 translation_ = 0.5 * Quaternion<T>(0, x, y, z) * rotation_;
             }


### PR DESCRIPTION
Hello Mihai,
Thank you for awesome project!
I've been reading through the code and I think I found a small bug in dual quaternion initialisation.
According to [Wikipedia](https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles), initialisation of rotation z should use `sin(pitch / 2)` not `cos(pitch /2)`.
Hope this helps!
Riku 